### PR TITLE
Fix issue that will redirect to success page

### DIFF
--- a/app/code/community/Wallee/Payment/controllers/TransactionController.php
+++ b/app/code/community/Wallee/Payment/controllers/TransactionController.php
@@ -75,9 +75,10 @@ class Wallee_Payment_TransactionController extends Mage_Core_Controller_Front_Ac
         $checkoutSession->getQuote()
             ->setIsActive(false)
             ->save();
-        $checkoutSession->setLastSuccessQuoteId($order->getQuoteId());
 
-        $checkoutSession->setLastOrderId($order->getId())
+        $checkoutSession->setLastQuoteId($order->getQuoteId())
+            ->setLastSuccessQuoteId($order->getQuoteId())
+            ->setLastOrderId($order->getId())
             ->setLastRealOrderId($order->getIncrementId());
 
         /* @var Wallee_Payment_Model_Service_Transaction $transactionService */


### PR DESCRIPTION
Without quote id you will never be redirected to the success page
Tested with OpenMage 20.2.0 on PHP 7.4