### PR TITLE
Add feature to process adminhtml creditmemo features

### DIFF
--- a/app/code/community/Wallee/Payment/Model/Entity/RefundJob.php
+++ b/app/code/community/Wallee/Payment/Model/Entity/RefundJob.php
@@ -64,6 +64,12 @@ class Wallee_Payment_Model_Entity_RefundJob extends Mage_Core_Model_Abstract
 
         if ($this->isObjectNew()) {
             $this->setCreatedAt(Mage::getSingleton('core/date')->date());
+
+            // store formdata from adminhtml creditmemo request
+            $postData = Mage::app()->getRequest()->getParam('creditmemo');
+            if ($postData !== null) {
+                $this->setData('adminhtml_formdata', json_encode($postData));
+            }
         }
     }
 
@@ -107,5 +113,20 @@ class Wallee_Payment_Model_Entity_RefundJob extends Mage_Core_Model_Abstract
         }
 
         return $this->_order;
+    }
+
+    /**
+     * Returns adminhtml formdata from creditmemo/save request
+     *
+     * @return array|mixed|null
+     */
+    public function getAdminhtmlFormdata()
+    {
+        $data = $this->getData('adminhtml_formdata');
+        if ($data !== null) {
+            $data = json_decode($data, true);
+        }
+
+        return $data;
     }
 }

--- a/app/code/community/Wallee/Payment/etc/config.xml
+++ b/app/code/community/Wallee/Payment/etc/config.xml
@@ -13,7 +13,7 @@
 <config>
 	<modules>
 		<Wallee_Payment>
-			<version>1.1.12</version>
+			<version>1.1.13</version>
 		</Wallee_Payment>
 	</modules>
 	<global>

--- a/app/code/community/Wallee/Payment/sql/wallee_payment_setup/upgrade-1.1.12-1.1.13.php
+++ b/app/code/community/Wallee/Payment/sql/wallee_payment_setup/upgrade-1.1.12-1.1.13.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * wallee Magento 1
+ *
+ * This Magento extension enables to process payments with wallee (https://www.wallee.com/).
+ *
+ * @package Wallee_Payment
+ * @author wallee AG (http://www.wallee.com/)
+ * @license http://www.apache.org/licenses/LICENSE-2.0  Apache Software License (ASL 2.0)
+ */
+$installer = $this;
+/* @var $installer Mage_Core_Model_Resource_Setup */
+
+$installer->startSetup();
+
+/**
+ * Add a new column to the wallee_payment/refund_job table that stores adminhtml formdata from creditmemo/save
+ */
+$installer->getConnection()->addColumn(
+    $installer->getTable('wallee_payment/refund_job'), 'adminhtml_formdata', array(
+    'type' => Varien_Db_Ddl_Table::TYPE_TEXT,
+    'length' => '64k',
+    'default' => NULL,
+    'nullable' => true,
+    'comment' => 'adminhtml post request creditmemo data'
+    )
+);
+
+$installer->endSetup();


### PR DESCRIPTION
When you create a credit memo in the backend, features such as defining "back to stock", sending a confirmation email or setting a comment are not available if the API does not process the refund directly (which was always the case before). If a credit memo is triggered by a webhook, all settings from the form are ignored.

With this pull request, the form data is cached when the RefundJob is created. If the refund is triggered by a webhook event, the form data is also processed.